### PR TITLE
fix: add padding to 404 page on mobile

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,7 +2,7 @@ import Link from '@/components/Link'
 
 export default function NotFound() {
   return (
-    <div className="flex flex-col items-start justify-start md:mt-24 md:flex-row md:items-center md:justify-center md:space-x-6">
+    <div className="flex flex-col items-start justify-start px-4 pt-16 sm:px-6 md:mt-24 md:flex-row md:items-center md:justify-center md:space-x-6 md:px-0 md:pt-0">
       <div className="space-x-2 pb-8 pt-6 md:space-y-5">
         <h1 className="text-6xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 md:border-r-2 md:px-6 md:text-8xl md:leading-14">
           404


### PR DESCRIPTION
## Summary

- Content was overflowing the left edge on mobile — no horizontal padding on the outer wrapper
- Adds `px-4 pt-16 sm:px-6` for mobile with `md:px-0 md:pt-0` resets so the desktop layout (`mt-24` + `justify-center`) is unaffected

## Test plan

- [x] Open `/404` on a mobile viewport — text should be inset from screen edge
- [x] Verify desktop layout unchanged