### PR TITLE
feat: redesign IdentityPanel with labeled zones and mobile strip

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import { ThemeProviders } from './theme-providers'
 import { Metadata } from 'next'
 import Script from 'next/script'
 import * as gtag from 'gtag'
+import { allBlogs } from 'contentlayer/generated'
 
 const plex_sans = IBM_Plex_Sans({
   weight: ['300', '400', '600'],
@@ -54,6 +55,7 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const postCount = allBlogs.filter((post) => !post.draft).length
   return (
     <html
       lang={siteMetadata.language}
@@ -95,7 +97,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
             {/* Body: identity panel (home only) + content */}
             <div className="flex flex-1">
-              <IdentityPanel />
+              <IdentityPanel postCount={postCount} />
               <div className="flex min-w-0 flex-1 flex-col">
                 <main className="flex-1">{children}</main>
                 <Footer />

--- a/components/IdentityPanel.tsx
+++ b/components/IdentityPanel.tsx
@@ -4,51 +4,99 @@ import { usePathname } from 'next/navigation'
 import Link from '@/components/Link'
 import siteMetadata from '@/data/siteMetadata'
 import headerNavLinks from '@/data/headerNavLinks'
+import tagData from 'app/tag-data.json'
 
-export default function IdentityPanel() {
+interface Props {
+  postCount: number
+}
+
+export default function IdentityPanel({ postCount }: Props) {
   const pathname = usePathname()
   if (pathname !== '/') return null
 
+  const topTags = Object.entries(tagData as Record<string, number>)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 6)
+    .map(([tag]) => tag)
+
   return (
     <aside className="hidden md:flex md:w-52 xl:w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] flex-col overflow-y-auto border-r border-gray-100 px-6 py-8 dark:border-gray-800 xl:px-8">
-      {/* Author name */}
-      <Link
-        href="/"
-        className="mb-3 block text-3xl font-light leading-none tracking-[-0.05em] text-gray-900 transition-colors hover:text-gray-500 dark:text-gray-100 dark:hover:text-gray-400"
-      >
-        {siteMetadata.headerTitle}
-      </Link>
+      {/* ABOUT zone */}
+      <div className="mb-8">
+        <p className="mb-3 font-mono text-2xs tracking-[0.2em] uppercase text-gray-300 dark:text-gray-700">
+          About
+        </p>
+        <p className="font-mono text-xs tracking-widest text-gray-400 dark:text-gray-600">
+          {siteMetadata.description}
+        </p>
+      </div>
 
-      {/* Bio label */}
-      <p className="mb-6 font-mono text-[12px] uppercase tracking-widest text-gray-400 dark:text-gray-600">
-        {siteMetadata.description}
-      </p>
-
-      {/* Nav links */}
-      <nav className="flex flex-col">
-        {headerNavLinks
-          .filter((link) => link.href !== '/')
-          .map((link) => (
+      {/* WRITING zone */}
+      <div className="mb-8">
+        <p className="mb-3 font-mono text-2xs tracking-[0.2em] uppercase text-gray-300 dark:text-gray-700">
+          Writing
+        </p>
+        <p className="mb-3 font-mono text-xs text-gray-400 dark:text-gray-500">
+          {postCount} posts on
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {/* {topTags.map((tag) => (
             <Link
-              key={link.href}
-              href={link.href}
-              className="group flex items-center gap-2 border-b border-gray-100 py-2.5 text-sm text-gray-500 transition-all last:border-0 hover:translate-x-0.5 hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
+              key={tag}
+              href={`/tags/${tag}`}
+              className="border border-gray-200 px-1.5 py-0.5 font-mono text-2xs text-gray-400 transition-colors hover:border-gray-400 hover:text-gray-700 dark:border-gray-800 dark:text-gray-600 dark:hover:border-gray-600 dark:hover:text-gray-300"
             >
-              <span className="text-gray-300 transition-colors group-hover:text-gray-500 dark:text-gray-700 dark:group-hover:text-gray-500">
-                —
-              </span>
-              {link.title}
+              {tag}
             </Link>
-          ))}
-      </nav>
+          ))} */}
+          {/* Identity tags — manually curated */}
+          {['agentic-ai', 'llms', 'digital-twins', 'data-engineering', 'data-visualization'].map(
+            (tag) => (
+              <Link
+                key={tag}
+                href={`/tags/${tag}`}
+                className="border border-gray-200 px-1.5 py-0.5 font-mono text-2xs text-gray-400 transition-colors hover:border-gray-400 hover:text-gray-700 dark:border-gray-800 dark:text-gray-600 dark:hover:border-gray-600 dark:hover:text-gray-300"
+              >
+                {tag}
+              </Link>
+            )
+          )}
+        </div>
+      </div>
 
-      {/* Social + stats */}
-      <div className="mt-auto border-t border-gray-100 pt-6 dark:border-gray-800">
+      {/* NAVIGATE zone */}
+      <div className="mb-auto">
+        <p className="mb-3 font-mono text-2xs tracking-[0.2em] uppercase text-gray-300 dark:text-gray-700">
+          Navigate
+        </p>
+        <nav className="flex flex-col">
+          {headerNavLinks
+            .filter((link) => link.href !== '/')
+            .map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="group flex items-center gap-2 border-b border-gray-100 py-2.5 text-sm text-gray-500 transition-all last:border-0 hover:translate-x-0.5 hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
+              >
+                <span className="text-gray-300 transition-colors group-hover:text-gray-500 dark:text-gray-700 dark:group-hover:text-gray-500">
+                  —
+                </span>
+                {link.title}
+              </Link>
+            ))}
+        </nav>
+      </div>
+
+      {/* CONNECT zone */}
+      <div className="border-t border-gray-100 pt-6 dark:border-gray-800">
+        <p className="mb-3 font-mono text-2xs tracking-[0.2em] uppercase text-gray-300 dark:text-gray-700">
+          Connect
+        </p>
         <div className="flex gap-4">
           {siteMetadata.github && (
             <Link
               href={siteMetadata.github}
-              className="border-b border-transparent font-mono text-[11px] text-gray-400 transition-colors hover:border-gray-900 hover:text-gray-900 dark:hover:border-gray-100 dark:hover:text-gray-100"
+              className="border-b border-transparent font-mono text-xs text-gray-400 transition-colors hover:border-gray-900 hover:text-gray-900 dark:hover:border-gray-100 dark:hover:text-gray-100"
             >
               github
             </Link>
@@ -56,9 +104,17 @@ export default function IdentityPanel() {
           {siteMetadata.linkedin && (
             <Link
               href={siteMetadata.linkedin}
-              className="border-b border-transparent font-mono text-[11px] text-gray-400 transition-colors hover:border-gray-900 hover:text-gray-900 dark:hover:border-gray-100 dark:hover:text-gray-100"
+              className="border-b border-transparent font-mono text-xs text-gray-400 transition-colors hover:border-gray-900 hover:text-gray-900 dark:hover:border-gray-100 dark:hover:text-gray-100"
             >
               linkedin
+            </Link>
+          )}
+          {siteMetadata.email && (
+            <Link
+              href={`mailto:${siteMetadata.email}`}
+              className="border-b border-transparent font-mono text-xs text-gray-400 transition-colors hover:border-gray-900 hover:text-gray-900 dark:hover:border-gray-100 dark:hover:text-gray-100"
+            >
+              email
             </Link>
           )}
         </div>


### PR DESCRIPTION
## Summary

- Removes duplicate logo mark from the panel (header already owns that identity)
- Replaces it with four labeled zones using tiny letter-spaced caps: **ABOUT** (bio), **WRITING** (post count + curated tag pills), **NAVIGATE** (nav links), **CONNECT** (social links)
- Adds a mobile-only compact strip (`md:hidden`) — the panel was previously invisible on small screens
- Passes `postCount` from `layout.tsx` (server component) as a prop; tag pills are manually curated identity tags

## Test plan

- [x] Home page desktop — four labeled zones visible in sidebar
- [ ] Home page mobile — compact bio + tags + socials strip appears above content
- [x] Non-home pages — panel renders nothing (existing behaviour)