### PR TITLE
feat: update pages and resume for minimalist redesign

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -12,7 +12,7 @@ export default function Home({ posts }: { posts: Post[] }) {
   const [featuredPost, ...recentPosts] = posts.slice(0, MAX_DISPLAY)
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-12 sm:px-8">
+    <div className="mx-auto max-w-5xl px-4 py-12 sm:px-8">
       {/* Section label */}
       <p className="text-xs tracking-widest text-gray-400 dark:text-gray-500">— latest</p>
 
@@ -41,7 +41,7 @@ export default function Home({ posts }: { posts: Post[] }) {
       )}
 
       {/* Recent posts — editorial list */}
-      <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+      <ul className="py-5 divide-y divide-gray-100 dark:divide-gray-800">
         {recentPosts.map((post) => (
           <li key={post.slug} className="py-5 first:pt-0 last:pb-0">
             <article className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-start sm:gap-4">

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -19,7 +19,7 @@ export default async function Page() {
   return (
     <ResumeClient
       data={resumeData}
-      sections={['education', 'experience', 'projects', 'awards']}
+      sections={['education', 'experience', 'projects', 'awards', 'publications']}
       heroImage={{ src: '/static/images/avatar.png', alt: 'Mia' }}
     />
   )

--- a/app/learning/page.tsx
+++ b/app/learning/page.tsx
@@ -7,7 +7,7 @@ export const metadata = genPageMetadata({ title: 'Learning' })
 
 export default function Learning() {
   return (
-    <div className="mx-auto max-w-3xl px-4 py-12 sm:px-8">
+    <div className="mx-auto max-w-5xl px-4 py-12 sm:px-8">
       <div className="mb-10">
         <p className="mb-1 text-2xs tracking-[0.13em] text-gray-400 dark:text-gray-600">
           — learning
@@ -16,7 +16,7 @@ export default function Learning() {
           Study with me
         </h1>
         <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
-          Let's learn it, write it and bring it all together for continous improvement.
+          Let's learn it, write it and bring it all together for continuous improvement.
         </p>
       </div>
 

--- a/app/resume/ResumeClient.tsx
+++ b/app/resume/ResumeClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState, type ReactNode } from 'react'
+import { useState } from 'react'
 import Image from '@/components/Image'
 import { ResumeData } from './types'
 
@@ -12,6 +12,10 @@ type ResumeSectionKey =
   | 'skills'
   | 'projects'
   | 'awards'
+
+// Shared tag class — outlined square, used everywhere
+const tagClass =
+  'border border-gray-100 dark:border-gray-800 px-2 py-0.5 font-mono text-2xs text-gray-400 dark:text-gray-600 rounded-sm'
 
 function SectionHeader({
   title,
@@ -65,21 +69,15 @@ function ExperienceItem({
   const hasMoreTags = tags.length > previewTags.length
 
   return (
-    <div className="relative grid gap-3 break-inside-avoid pl-4 md:grid-cols-[110px_1fr]">
-      <span
-        className="absolute left-0 top-2 h-full w-px bg-gray-100 dark:bg-gray-800"
-        aria-hidden="true"
-      />
-      <span
-        className="absolute left-[-3px] top-2 h-2 w-2 rounded-full bg-gray-300 dark:bg-gray-600"
-        aria-hidden="true"
-      />
-
-      <div className="flex flex-col font-mono text-xs text-gray-400 dark:text-gray-600">
+    <div className="grid grid-cols-[80px_1fr] gap-3 border-b border-gray-50 py-3 first:pt-0 last:border-0 last:pb-0 dark:border-gray-800/50">
+      {/* Dates */}
+      <div className="pt-0.5 font-mono text-2xs leading-relaxed text-gray-300 dark:text-gray-700">
         <span>{start}</span>
+        <br />
         <span>{end}</span>
       </div>
 
+      {/* Body */}
       <div className="flex flex-col gap-2">
         <button
           type="button"
@@ -87,18 +85,20 @@ function ExperienceItem({
           className="flex items-start justify-between gap-3 text-left transition-opacity hover:opacity-70 focus:outline-none"
           aria-expanded={expanded}
         >
-          <div className="flex flex-col leading-tight">
+          <div className="flex flex-col gap-0.5 leading-tight">
             <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
               {item.role}
             </span>
-            <span className="text-sm text-gray-500 dark:text-gray-400">{item.company}</span>
-            {item.location && (
-              <span className="text-xs text-gray-400 dark:text-gray-600">{item.location}</span>
-            )}
+            <span className="text-xs font-light text-gray-500 dark:text-gray-400">
+              {[item.company, item.location].filter(Boolean).join(' · ')}
+            </span>
           </div>
-          <span className="mt-0.5 text-sm text-gray-400">{expanded ? '−' : '+'}</span>
+          <span className="mt-0.5 shrink-0 font-mono text-xs text-gray-300 dark:text-gray-700">
+            {expanded ? '−' : '+'}
+          </span>
         </button>
 
+        {/* Expanded bullets */}
         {expanded && Array.isArray(item.bullets) && item.bullets.length > 0 && (
           <ul className="flex flex-col gap-1">
             {item.bullets.map((h, idx) => (
@@ -113,27 +113,24 @@ function ExperienceItem({
           </ul>
         )}
 
+        {/* Tags — preview when collapsed, full when expanded */}
         {!expanded && previewTags.length > 0 && (
           <div className="flex flex-wrap items-center gap-1.5">
             {previewTags.map((tag, idx) => (
-              <span
-                key={idx}
-                className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-              >
+              <span key={idx} className={tagClass}>
                 {tag}
               </span>
             ))}
-            {hasMoreTags && <span className="text-xs text-gray-400">…</span>}
+            {hasMoreTags && (
+              <span className="font-mono text-2xs text-gray-300 dark:text-gray-700">…</span>
+            )}
           </div>
         )}
 
         {expanded && Array.isArray(item.tags) && item.tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
             {item.tags.map((tag, idx) => (
-              <span
-                key={idx}
-                className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-              >
+              <span key={idx} className={tagClass}>
                 {tag}
               </span>
             ))}
@@ -162,31 +159,42 @@ function formatEducation(details?: string) {
 function EducationItem({ item }: { item: NonNullable<ResumeData['education']>[number] }) {
   const { degree, institution, bracket } = formatEducation(item.details)
   return (
-    <div className="flex flex-col gap-0.5 break-inside-avoid">
-      <h3 className="text-sm font-semibold leading-snug text-gray-900 dark:text-gray-100">
-        {degree}
+    <div className="grid grid-cols-[80px_1fr] items-baseline gap-3 py-2 first:pt-0 last:pb-0 border-b border-gray-50 dark:border-gray-800/50 last:border-0">
+      <div className="font-mono text-2xs text-gray-300 dark:text-gray-700 leading-relaxed">
+        {item.dates}
+      </div>
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{degree}</span>
         {institution && (
-          <span className="font-light text-gray-500 dark:text-gray-400">, {institution}</span>
+          <span className="text-xs font-light text-gray-500 dark:text-gray-400">{institution}</span>
         )}
         {bracket && (
-          <span className="font-light text-gray-400 dark:text-gray-600"> ({bracket})</span>
+          <span className="text-xs font-light text-gray-500 dark:text-gray-400">({bracket})</span>
         )}
-      </h3>
-      <div className="font-mono text-xs text-gray-400 dark:text-gray-600">{item.dates}</div>
+      </div>
     </div>
   )
 }
 
 function SkillsList({ items }: { items: NonNullable<ResumeData['skills']> }) {
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col divide-y divide-gray-50 dark:divide-gray-800/50">
       {items?.map((group, i) => (
-        <p key={i} className="text-2xs text-gray-900 dark:text-gray-100">
-          <span className="font-semibold">{group.category}:</span>{' '}
-          <span className="font-light text-gray-500 dark:text-gray-400">
-            {group.items.join(', ')}
+        <div
+          key={i}
+          className="grid grid-cols-[140px_1fr] items-start gap-4 py-3 first:pt-0 last:pb-0"
+        >
+          <span className="pt-0.5 font-mono text-2xs leading-relaxed text-gray-300 dark:text-gray-700">
+            {group.category}
           </span>
-        </p>
+          <div className="flex flex-wrap gap-1.5 self-start">
+            {group.items.map((item, idx) => (
+              <span key={idx} className={tagClass}>
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
       ))}
     </div>
   )
@@ -194,21 +202,44 @@ function SkillsList({ items }: { items: NonNullable<ResumeData['skills']> }) {
 
 function PublicationsList({ items }: { items?: NonNullable<ResumeData['publications']> }) {
   if (!items?.length) return null
+
+  const getType = (p: NonNullable<ResumeData['publications']>[number]) => {
+    if (p.journal) return 'journal'
+    if (p.booktitle) return 'conference'
+    return null
+  }
+
   return (
-    <ul className="flex flex-col gap-2">
-      {items.map((p, i) => (
-        <li key={i} className="flex gap-2 text-sm leading-relaxed">
-          <span className="text-gray-300 dark:text-gray-600">›</span>
-          <span>
-            <span className="font-semibold text-gray-900 dark:text-gray-100">{p.title}</span>
-            <span className="font-light text-gray-500 dark:text-gray-400">
-              {p.year ? ` (${p.year})` : ''}
-              {p.journal ? ` — ${p.journal}` : p.booktitle ? ` — ${p.booktitle}` : ''}
-              {p.author ? ` — ${p.author}` : ''}
+    <ul className="flex flex-col divide-y divide-gray-50 dark:divide-gray-800/50">
+      {items.map((p, i) => {
+        const type = getType(p)
+        const venue = p.journal || p.booktitle || ''
+        const authors = p.author || ''
+        return (
+          <li key={i} className="grid grid-cols-[24px_1fr] gap-3 py-3 first:pt-0 last:pb-0">
+            <span className="pt-0.5 font-mono text-2xs text-gray-300 dark:text-gray-700">
+              {String(i + 1).padStart(2, '0')}
             </span>
-          </span>
-        </li>
-      ))}
+            <div className="flex flex-col gap-1.5">
+              <p className="text-sm font-semibold leading-snug text-gray-900 dark:text-gray-100">
+                {p.title}
+              </p>
+              {venue && (
+                <p className="text-xs font-light text-gray-400 dark:text-gray-600">{venue}</p>
+              )}
+              {authors && (
+                <p className="text-xs font-light italic text-gray-400 dark:text-gray-600">
+                  {authors}
+                </p>
+              )}
+              <div className="flex flex-wrap gap-1.5">
+                {p.year && <span className={tagClass}>{p.year}</span>}
+                {type && <span className={tagClass}>{type}</span>}
+              </div>
+            </div>
+          </li>
+        )
+      })}
     </ul>
   )
 }
@@ -216,23 +247,23 @@ function PublicationsList({ items }: { items?: NonNullable<ResumeData['publicati
 function AwardsList({ items }: { items?: NonNullable<ResumeData['awards']> }) {
   if (!items?.length) return null
   return (
-    <ul className="flex flex-col gap-3">
+    <ul className="flex flex-col divide-y divide-gray-50 dark:divide-gray-800/50">
       {items.map((a, i) => {
         const titleParts = a.title?.split(' — ') || []
         const awardTitle = titleParts[0]?.trim() || ''
         const organization = titleParts.length > 1 ? titleParts.slice(1).join(' — ').trim() : ''
         return (
-          <li key={i} className="flex items-baseline gap-4">
-            <span className="w-10 shrink-0 font-mono text-xs text-gray-400 dark:text-gray-600">
-              {a.year}
-            </span>
-            <div>
-              <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          <li
+            key={i}
+            className="grid grid-cols-[80px_1fr] items-baseline gap-3 py-2 first:pt-0 last:pb-0"
+          >
+            <span className="font-mono text-2xs text-gray-300 dark:text-gray-700">{a.year}</span>
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+              <span className="text-sm font-semibold leading-snug text-gray-900 dark:text-gray-100">
                 {awardTitle}
               </span>
               {organization && (
-                <span className="text-sm font-light text-gray-500 dark:text-gray-400">
-                  {' — '}
+                <span className="text-xs font-light text-gray-500 dark:text-gray-400">
                   {organization}
                 </span>
               )}
@@ -247,50 +278,44 @@ function AwardsList({ items }: { items?: NonNullable<ResumeData['awards']> }) {
 function ProjectsList({ items }: { items?: NonNullable<ResumeData['projects']> }) {
   if (!items?.length) return null
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col divide-y divide-gray-50 dark:divide-gray-800/50">
       {items.map((p, i) => (
-        <div
-          key={i}
-          className="flex flex-col gap-2 rounded-lg border border-gray-100 p-4 transition-colors hover:border-gray-200 dark:border-gray-800 dark:hover:border-gray-700"
-        >
-          <div className="flex items-baseline justify-between gap-2">
-            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{p.title}</p>
-            {p.dates && (
-              <span className="flex-shrink-0 font-mono text-xs text-gray-400 dark:text-gray-600">
-                {p.dates}
-              </span>
+        <div key={i} className="grid grid-cols-[80px_1fr] gap-3 py-3 first:pt-0 last:pb-0">
+          <div className="pt-0.5 font-mono text-2xs leading-relaxed text-gray-300 dark:text-gray-700">
+            {p.dates || ''}
+          </div>
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-semibold leading-snug text-gray-900 dark:text-gray-100">
+              {p.title}
+            </p>
+            {p.description && (
+              <p className="text-xs font-light leading-relaxed text-gray-500 dark:text-gray-400">
+                {p.description}
+              </p>
+            )}
+            {p.links && Object.values(p.links).length > 0 && (
+              <div className="flex flex-wrap gap-3">
+                {Object.values(p.links).map((link, idx) => (
+                  <Link
+                    key={idx}
+                    href={link.url}
+                    className="font-mono text-xs text-gray-400 transition-colors hover:text-gray-900 dark:hover:text-gray-100"
+                  >
+                    {link.display || link.url} →
+                  </Link>
+                ))}
+              </div>
+            )}
+            {p.tech && p.tech.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {p.tech.map((tech, idx) => (
+                  <span key={idx} className={tagClass}>
+                    {tech}
+                  </span>
+                ))}
+              </div>
             )}
           </div>
-          {p.description && (
-            <p className="text-xs font-light leading-relaxed text-gray-500 dark:text-gray-400">
-              {p.description}
-            </p>
-          )}
-          {p.links && Object.values(p.links).length > 0 && (
-            <div className="flex flex-wrap gap-3">
-              {Object.values(p.links).map((link, idx) => (
-                <Link
-                  key={idx}
-                  href={link.url}
-                  className="text-xs text-gray-400 transition-colors hover:text-gray-900 dark:hover:text-gray-100"
-                >
-                  {link.display || link.url} →
-                </Link>
-              ))}
-            </div>
-          )}
-          {p.tech && p.tech.length > 0 && (
-            <div className="flex flex-wrap gap-1.5">
-              {p.tech.map((tech, idx) => (
-                <span
-                  key={idx}
-                  className="rounded-full bg-gray-100 px-2.5 py-0.5 text-2xs text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                >
-                  {tech}
-                </span>
-              ))}
-            </div>
-          )}
         </div>
       ))}
     </div>
@@ -322,7 +347,7 @@ export default function ResumeClient({
   const isSectionEnabled = (key: ResumeSectionKey) => !sections || sections.includes(key)
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12 sm:px-8 print:p-8" id="main-content">
+    <main className="mx-auto max-w-5xl px-4 py-12 sm:px-8 print:p-8" id="main-content">
       <section className="w-full space-y-8 print:space-y-6" aria-label="Resume Content">
         {!hideHero && (
           <header className="flex flex-col gap-4 print:gap-2">
@@ -343,16 +368,13 @@ export default function ResumeClient({
                 )}
               </div>
 
-              <div className="flex flex-col gap-1.5 items-center text-center md:order-1 md:items-start md:text-left">
+              <div className="flex flex-col items-center gap-1.5 text-center md:order-1 md:items-start md:text-left">
                 <p className="text-2xs tracking-[0.13em] text-gray-400 dark:text-gray-600">
                   — resume
                 </p>
                 <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
                   {data.name}
                 </h1>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Data Scientist · Analytics Engineer
-                </p>
                 <div className="mt-2 flex flex-col gap-1 text-sm text-gray-500 dark:text-gray-400">
                   {data.socials && Object.keys(data.socials).length > 0 ? (
                     Object.values(data.socials).map((s, i) => (
@@ -416,7 +438,7 @@ export default function ResumeClient({
                 anchorId="education"
               />
               {!collapsed['education'] && (
-                <div className="space-y-3">
+                <div>
                   {data.education.map((item, idx) => (
                     <EducationItem key={idx} item={item} />
                   ))}
@@ -434,12 +456,12 @@ export default function ResumeClient({
                 anchorId="experience"
               />
               {!collapsed['experience'] && (
-                <div className="space-y-4">
+                <div>
                   {data.experience.map((item, idx) => (
                     <ExperienceItem
                       key={idx}
                       item={item}
-                      expanded={expandedExp[idx] ?? idx === 0}
+                      expanded={expandedExp[idx] ?? false}
                       onToggle={() => toggleExperience(idx)}
                     />
                   ))}
@@ -510,7 +532,7 @@ export default function ResumeClient({
               </span>
               <Link
                 href="https://tieukhoimai.github.io/mia-resume-builder/cv.pdf"
-                className="w-full rounded-lg border border-gray-100 px-5 py-2 text-center text-sm text-gray-500 transition-colors hover:border-gray-300 hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-100 md:w-auto md:justify-self-center print:hidden order-first md:order-none"
+                className="order-first w-full rounded-lg border border-gray-100 px-5 py-2 text-center text-xs text-gray-500 transition-colors hover:border-gray-300 hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-100 md:order-none md:w-auto md:justify-self-center print:hidden"
               >
                 Download CV →
               </Link>

--- a/app/resume/types.ts
+++ b/app/resume/types.ts
@@ -1,5 +1,6 @@
 export type ResumeData = {
   name: string
+  tagline?: string
   socials?: Record<string, { url: string; display?: string }>
   headline?: string
   experience?: Array<{

--- a/app/series/[slug]/page.tsx
+++ b/app/series/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function SeriesPage({ params }: Props) {
   const seriesTitle = articles[0]?.series || 'Article Series'
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-12 sm:px-8">
+    <div className="mx-auto max-w-5xl px-4 py-12 sm:px-8">
       {/* Back link */}
       <Link
         href="/series"

--- a/app/series/page.tsx
+++ b/app/series/page.tsx
@@ -8,14 +8,15 @@ export const metadata = genPageMetadata({
 
 export default function SeriesPage() {
   return (
-    <div className="mx-auto max-w-3xl px-4 py-12 sm:px-8">
+    <div className="mx-auto max-w-5xl px-4 py-12 sm:px-8">
       <div className="mb-10">
-        <p className="mb-1 text-[10.5px] tracking-[0.13em] text-gray-400 dark:text-gray-600">
-          — series
-        </p>
+        <p className="mb-1 text-2xs tracking-[0.13em] text-gray-400 dark:text-gray-600">— series</p>
         <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
           Series
         </h1>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          Let's go deep, stay curious, and map it all out — one series at a time.
+        </p>
       </div>
       <SeriesList />
     </div>

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -11,18 +11,16 @@ export default async function Page() {
   const sortedTags = tagKeys.sort((a, b) => tagCounts[b] - tagCounts[a])
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-12 sm:px-8">
+    <div className="mx-auto max-w-5xl px-4 py-12 sm:px-8">
       <div className="mb-10">
-        <p className="mb-1 text-[10.5px] tracking-[0.13em] text-gray-400 dark:text-gray-600">
-          — tags
-        </p>
+        <p className="mb-1 text-2xs tracking-[0.13em] text-gray-400 dark:text-gray-600">— tags</p>
         <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
           Tags
         </h1>
       </div>
 
       {tagKeys.length === 0 ? (
-        <p className="text-[13px] text-gray-400 dark:text-gray-600">No tags found.</p>
+        <p className="text-xs text-gray-400 dark:text-gray-600">No tags found.</p>
       ) : (
         <div className="grid grid-cols-2 gap-x-12 sm:grid-cols-3">
           {sortedTags.map((t) => (
@@ -30,10 +28,10 @@ export default async function Page() {
               key={t}
               href={`/tags/${slug(t)}`}
               aria-label={`View posts tagged ${t}`}
-              className="flex justify-between border-b border-gray-100 py-2 text-[13px] transition-colors hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
+              className="flex justify-between border-b border-gray-100 py-2 text-xs transition-colors hover:text-gray-900 dark:border-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
             >
               <span className="text-gray-600 dark:text-gray-400">{t}</span>
-              <span className="font-mono text-[11px] text-gray-400 dark:text-gray-600">
+              <span className="font-mono text-2xs text-gray-400 dark:text-gray-600">
                 {tagCounts[t]}
               </span>
             </Link>


### PR DESCRIPTION
## Summary

- Revises about, learning, tags, series (list + detail), and Main entry point as part of the minimalist redesign pass
- Updates `ResumeClient` layout and `types.ts` for the redesigned resume page

## Test plan

- [x] `/about` — renders correctly
- [x] `/learning` — renders correctly
- [x] `/tags` — tag list displays
- [x] `/series` and `/series/[slug]` — series pages render
- [x] `/resume` — resume layout intact